### PR TITLE
Enable specifying a target profile name via the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,26 @@ mfa_serial: arn:aws:iam::000000000000:mfa/my_mfa_serial
 base_profile: some-base-profile # optional - this is the AWS profile you use to log into the authentication account.
 roles:
   - name: something-prod-readonly
-    default: yes # optional, but helpful!
+    default: yes # Optional, but helpful!
     arn: arn:aws:iam::000000000000:role/ReadOnly
-    aliases: # optional, and also helpful!
+    aliases: # Optional, and also helpful!
       - something-prod
       - prod-readonly
+    # target_aws_profile (Optional):
+    # This is the name of the profile that 'roo' will write to when '-write-profile' is specified on the command line.
+    # If not specified, using -write-profile will require -profile-target.
+    target_aws_profile: "roo-default"
 
   - name: something-prod-deleteonly
     arn: arn:aws:iam::000000000000:role/DeleteOnly
     aliases:
       - deleteprod
+    target_aws_profile: "my-other-profile"
 
   - name: something-test-developer
     arn: arn:aws:iam::111111111111:role/Developer
     aliases:
       - something-dev
       - test-dev
+    target_aws_profile: "yet-another-profile"
 ```

--- a/config/role_config.go
+++ b/config/role_config.go
@@ -2,8 +2,9 @@ package config
 
 // RoleConfig represents a single mapping of an account role to assume.
 type RoleConfig struct {
-	Name      string   `yaml:"name"`
-	ARN       string   `yaml:"arn"`
-	IsDefault bool     `yaml:"default"`
-	Aliases   []string `yaml:"aliases"`
+	Name             string   `yaml:"name"`
+	ARN              string   `yaml:"arn"`
+	IsDefault        bool     `yaml:"default"`
+	Aliases          []string `yaml:"aliases"`
+	TargetAWSProfile string   `yaml:"target_aws_profile"`
 }

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -4,17 +4,20 @@ roles:
   - name: something-prod-readonly
     default: yes
     arn: arn:aws:iam::000000000000:role/ReadOnly
+    target_aws_profile: "roo-default"
     aliases:
       - something-prod
       - prod-readonly
 
   - name: something-test-developer
     arn: arn:aws:iam::111111111111:role/Developer
+    target_aws_profile: "my-other-profile"
     aliases:
       - something-dev
       - test-dev
 
   - name: something-test-readonly
     arn: arn:aws:iam::111111111111:role/ReadOnly
+    target_aws_profile: "yet-another-profile"
     aliases:
       - test-readonly

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/jkueh/roo
 go 1.14
 
 require (
-	github.com/aws/aws-sdk-go v1.34.18
+	github.com/aws/aws-sdk-go v1.35.6
+	github.com/go-sql-driver/mysql v1.5.0 // indirect
+	github.com/stretchr/testify v1.5.1 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,14 @@
 github.com/aws/aws-sdk-go v1.34.18 h1:Mo/Clq3u1dQFzpg8YQqBii8m+Vl3fWIfHi6kXs5wpuM=
 github.com/aws/aws-sdk-go v1.34.18/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.35.6 h1:yt7L4aU4lYSNGiIWAsaCFCh1fdVsdscVYOtKcpD3TpQ=
+github.com/aws/aws-sdk-go v1.35.6/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -14,5 +19,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This PR includes a breaking change for users of `-write-profile` in `v0.0.9` or earlier.

* The `-write-profile` parameter is now a boolean
* The new `-target-profile` flag is used to specify the profile to write to, and takes precedence over the config file. It is only required when there is no config value present.

After this PR is merged I'll push a v0.1.0 release.

Resolves #8.